### PR TITLE
Use GitHub mirror of Angelscript sources

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "libs/liblichtenstein"]
 	path = libs/liblichtenstein
 	url = git@github.com:tristanseifert/lichtenstein-lib.git
+[submodule "libs/angelscript"]
+	path = libs/angelscript
+	url = git@github.com:codecat/angelscript-mirror.git

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,5 @@
 
 # Default ignored files
 /workspace.xml
+# Datasource local storage ignored files
+/dataSources.local.xml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,28 +80,28 @@ add_executable(server
 
 
 # compile/link angelscript, and the add-ons wfe want
-add_subdirectory(libs/angelscript-sdk/angelscript/projects/cmake)
+add_subdirectory(libs/angelscript/sdk/angelscript/projects/cmake)
 target_link_libraries(server ${ANGELSCRIPT_LIBRARY_NAME})
 
-include_directories(libs/angelscript-sdk/angelscript/include)
-include_directories(libs/angelscript-sdk/add_on)
+include_directories(libs/angelscript/sdk/angelscript/include)
+include_directories(libs/angelscript/sdk/add_on)
 
 target_sources(server PRIVATE
-        libs/angelscript-sdk/add_on/scriptbuilder/scriptbuilder.cpp
+        libs/angelscript/sdk/add_on/scriptbuilder/scriptbuilder.cpp
 
-        libs/angelscript-sdk/add_on/scriptstdstring/scriptstdstring.cpp
-        libs/angelscript-sdk/add_on/scriptstdstring/scriptstdstring_utils.cpp
+        libs/angelscript/sdk/add_on/scriptstdstring/scriptstdstring.cpp
+        libs/angelscript/sdk/add_on/scriptstdstring/scriptstdstring_utils.cpp
 
-        libs/angelscript-sdk/add_on/scriptarray/scriptarray.cpp
+        libs/angelscript/sdk/add_on/scriptarray/scriptarray.cpp
 
-        libs/angelscript-sdk/add_on/scriptdictionary/scriptdictionary.cpp
+        libs/angelscript/sdk/add_on/scriptdictionary/scriptdictionary.cpp
 
-        libs/angelscript-sdk/add_on/scriptmath/scriptmath.cpp
-        libs/angelscript-sdk/add_on/scriptmath/scriptmathcomplex.cpp
+        libs/angelscript/sdk/add_on/scriptmath/scriptmath.cpp
+        libs/angelscript/sdk/add_on/scriptmath/scriptmathcomplex.cpp
 
-        libs/angelscript-sdk/add_on/datetime/datetime.cpp
+        libs/angelscript/sdk/add_on/datetime/datetime.cpp
 
-        libs/angelscript-sdk/add_on/debugger/debugger.cpp)
+        libs/angelscript/sdk/add_on/debugger/debugger.cpp)
 
 
 # JSON library

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,1 +1,1 @@
-To properly build this project, you will need to [download the AngelScript SDK](http://www.angelcode.com/angelscript/downloads.html) (as of writing, the latest version is 2.32.0, released 2017-12-16) and into the `angelscript-sdk` folder. It will be built automatically through CMake and linked statically into the app.
+AngelScript is integrated via the [GitHub mirror](https://github.com/codecat/angelscript-mirror) of the official SVN repository; [see this page](https://www.angelcode.com/angelscript/wip.php) for more information.


### PR DESCRIPTION
Instead of requiring to manually download the AngelScript SDK into the sources directory, we now use the [GitHub mirror](https://github.com/codecat/angelscript-mirror) of the official [SVN](http://svn.code.sf.net/p/angelscript/code/trunk/) repository.

This makes it much easier to get started (all that's needed is to pull git submodules) working and compiling the server, and allows easier updates to make sure we always have the latest version of AngelScript.